### PR TITLE
[White Hat] Patch Security Headers

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,5 @@
+/
+  Content-Security-Policy: default-src 'self'; script-src 'self'; object-src 'none';
+  X-Frame-Options: SAMEORIGIN
+  Referrer-Policy: no-referrer
+  Strict-Transport-Security: max-age=63072000; includeSubDomains; preload


### PR DESCRIPTION
This patch adds secure headers based on the White Hat scan:

- Added CSP header in `_headers` to block inline scripts and external sources.
- Added X-Frame-Options to prevent clickjacking.
- Added Referrer-Policy to protect referrer leakage.
- Added HSTS header to force HTTPS.